### PR TITLE
Add proper stars/keys access rules

### DIFF
--- a/locations/basement.json
+++ b/locations/basement.json
@@ -3,6 +3,7 @@
 	"name": "Basement",
 	"chest_unopened_img": "images/items/powerstar.png",
 	"chest_opened_img": "images/items/powerstaroff.png",
+	"access_rules": ["$basement_key"],
 	"children": [
 	{
 		"name": "Hazy Maze Cave",

--- a/locations/mainfloor.json
+++ b/locations/mainfloor.json
@@ -325,7 +325,7 @@
 	},
 	{
 		"name": "Tower of the Wing Cap",
-		"access_rules": [],
+		"access_rules": ["$ten_stars"],
 		"visibility_rules": [],
 		"sections": [
 			{
@@ -415,7 +415,7 @@
 	},
 	{
 		"name": "The Secret Aquarium",
-		"access_rules": ["$three_stars", "$aquarium"],
+		"access_rules": ["$three_stars, $aquarium"],
 		"visibility_rules": [],
 		"sections": [
 			{

--- a/locations/mainfloor.json
+++ b/locations/mainfloor.json
@@ -64,7 +64,7 @@
 	},
 	{
 		"name": "Whomp's Fortress",
-		"access_rules": [],
+		"access_rules": ["$one_star"],
 		"visibility_rules": [],
 		"sections": [
 			{
@@ -124,7 +124,7 @@
 	},
 	{
 		"name": "Jolly Roger Bay",
-		"access_rules": [],
+		"access_rules": ["$three_stars"],
 		"visibility_rules": [],
 		"sections": [
 			{
@@ -183,7 +183,7 @@
 	},
 	{
 		"name": "Cool Cool Mountain",
-		"access_rules": [],
+		"access_rules": ["$three_stars"],
 		"visibility_rules": [],
 		"sections": [
 			{
@@ -349,7 +349,7 @@
 	},
 	{
 		"name": "The Princess's Secret Slide",
-		"access_rules": [],
+		"access_rules": ["$one_star"],
 		"visibility_rules": [],
 		"sections": [
 			{
@@ -373,7 +373,7 @@
 	},
 	{
 		"name": "Bowser in the Dark World",
-		"access_rules": [],
+		"access_rules": ["$eight_stars"],
 		"visibility_rules": [],
 		"sections": [
 			{
@@ -415,7 +415,7 @@
 	},
 	{
 		"name": "The Secret Aquarium",
-		"access_rules": ["$aquarium"],
+		"access_rules": ["$three_stars", "$aquarium"],
 		"visibility_rules": [],
 		"sections": [
 			{

--- a/locations/topfloor.json
+++ b/locations/topfloor.json
@@ -3,6 +3,7 @@
 	"name": "Second Floor",
 	"chest_unopened_img": "images/items/powerstar.png",
 	"chest_opened_img": "images/items/powerstaroff.png",
+	"access_rules": ["$top_floor_key"],
 	"children": [
 	{
 		"name": "Snowman's Land",

--- a/scripts/logic.lua
+++ b/scripts/logic.lua
@@ -20,6 +20,10 @@ function eight_stars()
 	return has("powerstar", 8)
 end
 
+function ten_stars()
+	return has("powerstar", 10)
+end
+
 function basement_key()
 	return has("basementkey") or has("progkey_1")
 end

--- a/scripts/logic.lua
+++ b/scripts/logic.lua
@@ -8,6 +8,26 @@ function has(item, amount)
     end
 end
 
+function one_star()
+	return has("powerstar")
+end
+
+function three_stars()
+	return has("powerstar", 3)
+end
+
+function eight_stars()
+	return has("powerstar", 8)
+end
+
+function basement_key()
+	return has("basementkey") or has("progkey_1")
+end
+
+function top_floor_key()
+	return has("topfloorkey") or has("progkey_2")
+end
+
 function bob_island()
 	return has("bob") or (has("cannons") and has("wc") and has("tj")) or (has("caps") and has("cannons") and has("lj"))
 end


### PR DESCRIPTION
Add stars requirements to access levels:
- 1 for WF and Secret Slide
- 3 for JRB, Secret Aquarium, and CCM
- 8 for BitDW
- 10 for Tower of the Wing Cap

Add key requirements to access floors:
- Basement key or progressive key 1 for basement access (doesn't need the progressive key 2 check since it inherits the item code)
- Top floor key or progressive key 2 for top floor access